### PR TITLE
fix kqueue EV_SET bug

### DIFF
--- a/ext/evt/kqueue.h
+++ b/ext/evt/kqueue.h
@@ -21,13 +21,13 @@ VALUE method_scheduler_kqueue_register(VALUE self, VALUE io, VALUE interest) {
 
     if (ruby_interest & readable) {
         EV_SET(&events[0], fd, EVFILT_READ, EV_ADD|EV_ENABLE|EV_ONESHOT, 0, 0, (void*) io);
-        kevent(kq, &events[0], 1, NULL, 0, NULL); // TODO: Check the return value
     }
 
     if (ruby_interest & writable) {
         EV_SET(&events[1], fd, EVFILT_WRITE, EV_ADD|EV_ENABLE|EV_ONESHOT, 0, 0, (void*) io);
-        kevent(kq, &events[1], 1, NULL, 0, NULL); // TODO: Check the return value
     }
+
+    kevent(kq, &events, 2, NULL, 0, NULL); // TODO: Check the return value
 
     return Qnil;
 }

--- a/ext/evt/kqueue.h
+++ b/ext/evt/kqueue.h
@@ -10,7 +10,7 @@ VALUE method_scheduler_kqueue_init(VALUE self) {
 }
 
 VALUE method_scheduler_kqueue_register(VALUE self, VALUE io, VALUE interest) {
-    struct kevent event;
+    struct kevent events[2];
     u_short event_flags = 0;
     ID id_fileno = rb_intern("fileno");
     int kq = NUM2INT(rb_iv_get(self, "@kq"));
@@ -20,15 +20,15 @@ VALUE method_scheduler_kqueue_register(VALUE self, VALUE io, VALUE interest) {
     int writable = NUM2INT(rb_const_get(rb_cIO, rb_intern("WRITABLE")));
 
     if (ruby_interest & readable) {
-        event_flags |= EVFILT_READ;
+        EV_SET(&events[0], fd, EVFILT_READ, EV_ADD|EV_ENABLE|EV_ONESHOT, 0, 0, (void*) io);
+        kevent(kq, &events[0], 1, NULL, 0, NULL); // TODO: Check the return value
     }
 
     if (ruby_interest & writable) {
-        event_flags |= EVFILT_WRITE;
+        EV_SET(&events[1], fd, EVFILT_WRITE, EV_ADD|EV_ENABLE|EV_ONESHOT, 0, 0, (void*) io);
+        kevent(kq, &events[1], 1, NULL, 0, NULL); // TODO: Check the return value
     }
 
-    EV_SET(&event, fd, event_flags, EV_ADD|EV_ENABLE|EV_ONESHOT, 0, 0, (void*) io);
-    kevent(kq, &event, 1, NULL, 0, NULL); // TODO: Check the return value
     return Qnil;
 }
 


### PR DESCRIPTION
Hi,

I find using `Net::HTTP` will hangs forever with kqueue on mac like issue #6 , for example:

```ruby
require 'evt'
require 'net/http'

scheduler = Evt::Scheduler.new

Fiber.set_scheduler scheduler

100.times do
  Fiber.schedule do
    p Net::HTTP.get('httpbin.org', '/ip')
  end
end
```

After some researching, I found this problem is trigged in `ext/evt/kqueue.h`:

```c
    if (ruby_interest & readable) {
        event_flags |= EVFILT_READ;
    }

    if (ruby_interest & writable) {
        event_flags |= EVFILT_WRITE;
    }

    EV_SET(&event, fd, event_flags, EV_ADD|EV_ENABLE|EV_ONESHOT, 0, 0, (void*) io);
```

EVFILT_READ == ffffffff
EVFILT_WRITE == fffffffe

That makes EVFILT_READ | EVFILT_WRITE == EVFILT_READ and the script will hang on one event.

The result is that "or"-ing them together makes kqueue wait for READ events only. Flags can be "or"-ed but filters should not.

So this patch tries to create two events and this problem is solved.

